### PR TITLE
fix: include `_` and `.` as valid characters in slug regex

### DIFF
--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -38,7 +38,7 @@ getSlug() {
       PROJECT_SLUG="${BASH_REMATCH[1]}"
     fi
   else
-    REGEXP="com\/([A-Za-z]+\/[A-Za-z0-9-]+\/[A-Za-z0-9-]+)\/"
+    REGEXP="com\/([A-Za-z]+\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)\/"
     if [[ $CIRCLE_BUILD_URL =~ $REGEXP ]]; then
       PROJECT_SLUG="${BASH_REMATCH[1]}"
     fi


### PR DESCRIPTION
### Changes

Include every special character allowed in a repository name and username. See here for more information: https://stackoverflow.com/a/59082561