### PR TITLE
workaround for ZSH + BASH

### DIFF
--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -72,7 +72,7 @@ remove_duplicates() {
       TRIMMED_VALUE="$(echo -e "${single_value}" | tr -d '[:space:]')"
 
       # If the trimmed value has not been seen before, add it to the UNIQUE_KEYS array and mark it as seen
-      if [[ ! -v seen["$TRIMMED_VALUE"] ]]; then
+      if [[ -z seen["$TRIMMED_VALUE"] ]]; then
         UNIQUE_KEYS+=("$TRIMMED_VALUE")
         seen["$TRIMMED_VALUE"]=1
       fi


### PR DESCRIPTION
instead of using `! -v` to see if the variable has not been set, we use `-z` to see if it is 0 length. Fixes #18