### PR TITLE
fix: trigger correct shell

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -75,5 +75,6 @@ steps:
         JSON_DEPLOYMENT_PAYLOAD: <<include(scripts/deployment_payload.json)>>
         JIRA_BOOL_DEBUG: <<parameters.debug>>
         JIRA_BOOL_IGNORE_ERRORS: <<parameters.ignore_errors>>
+        JIRA_SCRIPT_NOTIFY: <<include(scripts/notify.sh)>>
       name: Notify Jira
-      command: <<include(scripts/notify.sh)>>
+      command: <<include(scripts/run_notify.sh)>>

--- a/src/scripts/run_notify.sh
+++ b/src/scripts/run_notify.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# This script requires Bash v4+ or zsh.
+# MacOS on CircleCI ships with Bash v3.x as the default shell
+# This script determines which shell to execute the notify script in.
+
+if [[ "$(uname -s)" == "Darwin" && "$SHELL" != "/bin/zsh" ]]; then
+  echo "Running in ZSH on MacOS"
+  /bin/zsh -c "setopt KSH_ARRAYS BASH_REMATCH; $JIRA_SCRIPT_NOTIFY"
+else 
+  /bin/bash -c "$JIRA_SCRIPT_NOTIFY"
+fi


### PR DESCRIPTION
## ISSUE

```
/bin/bash: -c: line 74: conditional binary operator expected

Exited with code exit status 2
```

## CAUSE

Features utilized in the bash of this orb such as associative arrays require BASH 4.0, the CircleCI Mac VMs have set BASH to the default shell rather than ZSH, but, Mac ships with BASH 3.5. Switching to ZSH was a viable option but did require setting some additional flags to force ZSH to behave more similarly to BASH.

## Resolves

- #15 
- #18

## Resolution

The main script has been moved into a new file which is injected as an environment variable. The script that is ran by default now simply detects which shell to execute the main script in.