### PR TITLE
Adding when: always attribute to notify command

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -78,3 +78,4 @@ steps:
         JIRA_SCRIPT_NOTIFY: <<include(scripts/notify.sh)>>
       name: Notify Jira
       command: <<include(scripts/run_notify.sh)>>
+      when: always


### PR DESCRIPTION
### Checklist

- [n/a] All new jobs, commands, executors, parameters have descriptions
- [n/a] Examples have been added for any significant new features
- [n/a] README has been updated, if necessary

### Motivation, issues
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
The current command doesn't run if any of the previous steps fails, only on success (issue reported by user).

### Description
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
Adding `when: always` to the `Notify Jira` command will allow jira notifications in failed jobs.

Fixes #28 .