### PR TITLE
Support using `jira/notify` multiple times with states

### DIFF
--- a/src/commands/notify.yml
+++ b/src/commands/notify.yml
@@ -47,6 +47,17 @@ parameters:
     description: "Ignore errors. Errors posting to Atlassian will not result in failed builds unless disabled."
     type: boolean
     default: true
+  state:
+    description: >
+      A valid Jira state for the build/deployment. If set as `unknown` (default),
+      then the state will be determined by the job status as `successful` or `failed`.
+      `rolled_back` is only valid for deployments.
+
+      See https://developer.atlassian.com/cloud/jira/software/rest/api-group-deployments/#api-rest-deployments-0-1-bulk-post or
+      https://developer.atlassian.com/cloud/jira/software/rest/api-group-builds/#api-rest-builds-0-1-bulk-post
+    type: enum
+    enum: [unknown, pending, in_progress, cancelled, failed, rolled_back, successful]
+    default: unknown
 steps:
   - run:
       when: on_fail
@@ -58,6 +69,8 @@ steps:
       when: on_success
       name: "Jira - Detecting Job Status: Successful"
       environment:
+        JIRA_VAL_JOB_TYPE: <<parameters.job_type>>
+        JIRA_VAL_STATE: <<parameters.state>>
         JOB_STATUS: "successful"
       command: <<include(scripts/detect.sh)>>
   - run:

--- a/src/scripts/detect.sh
+++ b/src/scripts/detect.sh
@@ -1,3 +1,12 @@
 #!/bin/bash
 
-echo "${JOB_STATUS}" >/tmp/circleci_jira_status
+jira_status=${JIRA_VAL_STATE:-$JOB_STATUS}
+
+if [[ "${JIRA_VAL_JOB_TYPE}" == "build" && "${JIRA_VAL_STATE}" == "rolled_back" ]]; then
+  echo "Cannot use 'rolled_back' build job type. Using '${JOB_STATUS}'"
+  jira_status="${JOB_STATUS}"
+elif [[ "${JIRA_VAL_STATE}" == "unknown" ]]; then
+  jira_status="${JOB_STATUS}"
+fi
+
+echo "${jira_status}" >/tmp/circleci_jira_status

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -246,6 +246,11 @@ PROJECT_VCS=""
 PROJECT_SLUG=""
 JIRA_ISSUE_KEYS=() # Set in getIssueKeys
 
+if [[ "$JIRA_BUILD_STATUS" == "failed" && -f "/tmp/circleci_jira_failed_reported" ]]; then
+  echo "Failed status previously reported in this workflow. Skipping"
+  errorOut 0
+fi
+
 # Built-ins - For reference
 # CIRCLE_BUILD_URL is the URL of the current build
 # CIRCLE_SHA1 is the commit hash of the current build
@@ -314,6 +319,15 @@ main() {
     echo "Unable to determine job type"
     exit 1 # Critical error, do not skip
   fi
+
+  if [[ "$JIRA_BUILD_STATUS" == "failed" ]]; then
+    # Mark that we've successfully reported the error. This file is
+    # used above to prevent sending the failure notification with
+    # multiple uses of the jira/notify command for different 
+    # successful deployment states since those jobs will always run
+    touch /tmp/circleci_jira_failed_reported
+  fi
+
   printf "\nJira notification sent!\n\n"
   MSG=$(printf "sent=true")
   log "$MSG"


### PR DESCRIPTION
Jira deployments and builds support multiple states to give introspection into the deployment flow. Currently, the orb only allows sending `failed` or `successful`.

This change allows using `jira/notify` multiple times in order to send other states like `pending`, `in_progress`, or `rolled_back` depending on the needs to the user workflow