### PR TITLE
Always Use `zsh` for MacOS to Run `notify` Script

### DIFF
--- a/src/scripts/run_notify.sh
+++ b/src/scripts/run_notify.sh
@@ -4,9 +4,9 @@
 # MacOS on CircleCI ships with Bash v3.x as the default shell
 # This script determines which shell to execute the notify script in.
 
-if [[ "$(uname -s)" == "Darwin" && "$SHELL" != "/bin/zsh" ]]; then
+if [[ "$(uname -s)" == "Darwin" ]]; then
   echo "Running in ZSH on MacOS"
   /bin/zsh -c "setopt KSH_ARRAYS BASH_REMATCH; $JIRA_SCRIPT_NOTIFY"
-else 
+else
   /bin/bash -c "$JIRA_SCRIPT_NOTIFY"
 fi


### PR DESCRIPTION
https://github.com/CircleCI-Public/jira-orb/pull/26 unblocked usage of this orb for CircleCI-hosted MacOS executors that set their default shell as `bash`.

However, when using this orb on a self-hosted MacOS runner that uses `zsh` as its default shell, `zsh` is not selected and failure occurs:

<img width="817" alt="Cursor_and_generate_beta_build__551219__-_doximity_iOS-Doximity" src="https://github.com/user-attachments/assets/7d0ded53-bc3c-4dd4-892c-56c3aa973f30">

My proposal is that `zsh` be used for MacOS executors regardless of the default shell setting - this should enable this orb to be used for _any_ MacOS executor type.

Using a fork of this orb that includes this change, I am able to see successful results when running on a self-hosted MacOS executor:

<img width="665" alt="Cursor_and_generate_beta_build__551424__-_doximity_iOS-Doximity" src="https://github.com/user-attachments/assets/e885cf6a-b2b6-489d-805f-fd0c76364c56">
