### PR TITLE
Check for CircleCI CLI Install and Handle Like Other Errors if Not Present

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@12.0
-  shellcheck: circleci/shellcheck@3.1
+  orb-tools: circleci/orb-tools@12.3
+  shellcheck: circleci/shellcheck@3.2
 
 filters: &filters
   tags:
@@ -25,6 +25,5 @@ workflows:
           pipeline_number: << pipeline.number >>
           vcs_type: << pipeline.project.type >>
           orb_name: jira
-          requires:
-            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
+          requires: [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -37,8 +37,7 @@ executors:
       - image: cimg/base:current
   macos:
     macos:
-      xcode: 15.0.0
-      resource_class: macos.x86.medium.gen2
+      xcode: 15.2.0
 
 jobs:
   test:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -2,7 +2,7 @@ version: 2.1
 orbs:
   # Your orb will be automatically injected here during the pipeline.
   # Reference your orb's jobs and commands below as they will exist when built.
-  orb-tools: circleci/orb-tools@12.0
+  orb-tools: circleci/orb-tools@12.3
   # The orb definition is intentionally not included here. It will be injected into the pipeline.
   jira: {}
 

--- a/src/scripts/notify.sh
+++ b/src/scripts/notify.sh
@@ -65,7 +65,7 @@ remove_duplicates() {
   declare -A seen
   # Declare UNIQUE_KEYS as a global variable
   UNIQUE_KEYS=()
-  
+
   for value in "$@"; do
     # Splitting value into array by space, considering space-separated keys in a single string
     for single_value in $value; do
@@ -121,7 +121,7 @@ getIssueKeys() {
   JIRA_ISSUE_KEYS=$(printf '%s\n' "${KEY_ARRAY[@]}" | jq -R . | jq -s .)
   echo "Issue keys found:"
   echo "$JIRA_ISSUE_KEYS" | jq -r '.[]'
-  
+
   # Export JIRA_ISSUE_KEYS for use in other scripts or sessions
   export JIRA_ISSUE_KEYS
 }
@@ -215,6 +215,21 @@ getTagKeys() {
   done
   echo "${TAG_KEYS[@]}"
 }
+
+circleciCliCheck() {
+  HAS_CIRCLECI_CLI=0
+  which circleci > circleci-location.log || HAS_CIRCLECI_CLI=$?
+  if [[ "$HAS_CIRCLECI_CLI" != 0 ]]; then
+    echo "CircleCI CLI not installed, unable to continue!"
+    errorOut 1
+  else
+    echo "CircleCI CLI installed at: $(cat circleci-location.log)"
+    rm circleci-location.log
+  fi
+}
+
+# Verify presence of circleci
+circleciCliCheck
 
 # Sanetize the input
 # JIRA_VAL_JOB_TYPE - Enum string value of 'build' or 'deploy'


### PR DESCRIPTION
This is in response to another issue I observed when using this orb on our self-hosted MacOS runners. While presence of the `circleci` binary can _generally_ be assumed even on self-hosted runners, we did see cases where that was untrue, which resulted in errors like this:

<img width="479" alt="generate_beta_build__70576__-_doximity_ios-amion-v2" src="https://github.com/user-attachments/assets/9d9f06d0-c741-4872-81d5-a802d0804e0e">


This PR adds a quick check at the beginning of the `notify.sh` execution to ensure `circleci` is present. If not, it will be handled like other errors via `errorOut`, causing CI build failure only if the `ignore_errors` orb parameter is set to `false`.

When `circleci` is not detected:
<img width="528" alt="Step_-_generate_beta_build__70685__-_doximity_ios-amion-v2" src="https://github.com/user-attachments/assets/1eb34c6b-b7ec-4455-8a83-eb68e8c746fe">


When it is:
<img width="580" alt="Step_-_generate_beta_build__70688__-_doximity_ios-amion-v2" src="https://github.com/user-attachments/assets/9df82e15-6200-463c-aaee-945a95f92a2e">