### PR TITLE
Add shwordsplit to zsh execution

### DIFF
--- a/src/scripts/run_notify.sh
+++ b/src/scripts/run_notify.sh
@@ -6,7 +6,7 @@
 
 if [[ "$(uname -s)" == "Darwin" ]]; then
   echo "Running in ZSH on MacOS"
-  /bin/zsh -c "setopt KSH_ARRAYS BASH_REMATCH; $JIRA_SCRIPT_NOTIFY"
+  /bin/zsh -c "setopt KSH_ARRAYS BASH_REMATCH SHWORDSPLIT; $JIRA_SCRIPT_NOTIFY"
 else
   /bin/bash -c "$JIRA_SCRIPT_NOTIFY"
 fi


### PR DESCRIPTION
Resolves #46
Add shwordsplit to zsh execution so the string array split are managed the same way as in bash.